### PR TITLE
Avoid duplicate descriptions in calendars

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
@@ -480,6 +480,17 @@ public class JdbcGtfsSnapshotter {
             LOG.info(updateOtherSql);
             int calendarsUpdated = statement.executeUpdate(updateOtherSql);
             LOG.info("Updated description for {} calendars", calendarsUpdated);
+
+            // Check if there are duplicate descriptions, in which case set the description to be the service_id which is unique
+            String avoidDuplicateDescriptionSql = String.format(
+                    "update %1$scalendar set description = service_id " +
+                    "from (select description, count(*) as duplicate_count from %1$scalendar group by description) as duplicate_descriptions " +
+                    "where %1$scalendar.description = duplicate_descriptions.description and duplicate_descriptions.duplicate_count > 1",
+                    tablePrefix
+            );
+            LOG.info(avoidDuplicateDescriptionSql);
+            int duplicatesAvoided = statement.executeUpdate(avoidDuplicateDescriptionSql);
+            LOG.info("Updated description for {} calendars to avoid duplicates", duplicatesAvoided);
         }
         if (Table.TRIPS.name.equals(table.name)) {
             // Update use_frequency field for patterns. This sets all patterns that have a frequency trip to use

--- a/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
+++ b/src/main/java/com/conveyal/gtfs/loader/JdbcGtfsSnapshotter.java
@@ -490,7 +490,7 @@ public class JdbcGtfsSnapshotter {
             );
             LOG.info(avoidDuplicateDescriptionSql);
             int duplicatesAvoided = statement.executeUpdate(avoidDuplicateDescriptionSql);
-            LOG.info("Updated description for {} calendars to avoid duplicates", duplicatesAvoided);
+            LOG.info("Updated duplicate descriptions for {} calendars", duplicatesAvoided);
         }
         if (Table.TRIPS.name.equals(table.name)) {
             // Update use_frequency field for patterns. This sets all patterns that have a frequency trip to use


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

The default description for a calendar in GTFS-lib will be autopopulated with a concatenation of the days of service it operates on. However, if multiple calendars operate on the same set of days, this will create duplicate descriptions which can become an issue for the datatools-ui display. This PR conditionally overrides any duplicates with the service-id, which is at least more useful than displaying duplicates. 

You can test this with datatools-server set up to use this gtfs-lib hash and the latest datatools-ui. 