### PR TITLE
increase error priority of Shared Stops Errors

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
+++ b/src/main/java/com/conveyal/gtfs/error/NewGTFSErrorType.java
@@ -89,7 +89,7 @@ public enum NewGTFSErrorType {
     // Shared Stops-specifc errors.
     MULTIPLE_SHARED_STOPS_GROUPS(Priority.HIGH, "A GTFS stop belongs to more than one shared-stop group, or belongs to the same shared-stop group twice."),
     SHARED_STOP_GROUP_MULTIPLE_PRIMARY_STOPS(Priority.HIGH, "A shared-stop group has multiple primary stops."),
-    SHARED_STOP_GROUP_ENTITY_DOES_NOT_EXIST(Priority.MEDIUM, "The stop referenced by a shared-stop does not exist in the feed it was said to exist in."),
+    SHARED_STOP_GROUP_ENTITY_DOES_NOT_EXIST(Priority.HIGH, "The stop referenced by a shared-stop does not exist in the feed it was said to exist in."),
 
     // Unknown errors.
     OTHER(Priority.LOW, "Other errors.");


### PR DESCRIPTION
Small patch to make shared stops errors show up as more serious errors