### PR TITLE
ci(maven): Use GitHub cache action v4.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
         # Add yarn path to GITHUB_PATH so that global package is executable.
         echo "$(yarn global bin)" >> $GITHUB_PATH
     - name: Setup Maven Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: ~/.m2


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [na] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [na] The description lists all applicable issues this PR seeks to resolve
- [na] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Upgrade GitHub's maven cache action. [cache v2 is removed as of Feb 1, 2025](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/).

