### PR TITLE
Bump Node to version 22 in Github action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,11 +29,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    # Install node 20.11.0 (LTS) for running maven-semantic-release.
-    - name: Use Node.js 20.X
+    # Install node 22 (LTS) for running maven-semantic-release.
+    - name: Use Node.js 22.X
       uses: actions/setup-node@v1
       with:
-        node-version: 20.11.0
+        node-version: 22.x
     - name: Install maven-semantic-release
       # FIXME: Enable cache for node packages (add package.json?)
       run: |
@@ -63,11 +63,11 @@ jobs:
           # See https://github.com/conveyal/gtfs-lib/issues/193.
           #
       # The git commands get the commit hash of the HEAD commit and the commit just before HEAD.
-    # Install node 14+ for running maven-semantic-release.
-    - name: Use Node.js 20.X
+    # Install node for running maven-semantic-release.
+    - name: Use Node.js 22.X
       uses: actions/setup-node@v1
       with:
-        node-version: 20.11.0
+        node-version: 22.x
     - name: Run maven-semantic-release
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

GitHub actions no longer work with Node version 20 so updating to version 22.
