### PR TITLE
Fix missing fare leg join rules table

### DIFF
--- a/src/main/java/com/conveyal/gtfs/loader/Table.java
+++ b/src/main/java/com/conveyal/gtfs/loader/Table.java
@@ -569,6 +569,7 @@ public class Table {
         STOPS,
         AREAS,
         RIDER_CATEGORIES,
+        FARE_LEG_JOIN_RULES,
         FARE_RULES,
         PATTERN_STOP,
         TRANSFERS,

--- a/src/main/java/com/conveyal/gtfs/model/FareTransferRule.java
+++ b/src/main/java/com/conveyal/gtfs/model/FareTransferRule.java
@@ -58,7 +58,7 @@ public class FareTransferRule extends Entity {
         statement.setString(oneBasedIndex, fare_product_id);
     }
 
-    public static class Loader extends Entity.Loader<FareLegRule> {
+    public static class Loader extends Entity.Loader<FareTransferRule> {
 
         public Loader(GTFSFeed feed) {
             super(feed, TABLE_NAME);


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Fare leg join rules table was missing from `Table.tablesInOrder` which is used all over the place!
